### PR TITLE
Exception message substitution in main log message

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -102,7 +102,11 @@ class Logger implements LoggerInterface
 
         $replacements = [];
         foreach ($context as $key => $value) {
-            $replacements['{' . $key . '}'] = $value;
+            if ($key === 'exception' && $value instanceof Exception) {
+                $replacements['{' . $key . '}'] = $value->getMessage();
+            } else {
+                $replacements['{' . $key . '}'] = $value;
+            }
         }
 
         return strtr($message, $replacements);

--- a/test/suite/LoggerTest.php
+++ b/test/suite/LoggerTest.php
@@ -112,10 +112,10 @@ class LoggerTest extends PHPUnit_Framework_TestCase
 
     public function testLogException()
     {
-        $exception = new Exception('Some exception.');
+        $exception = new Exception('This is the exception message.');
 
         $this->logger->error(
-            'Some test error.',
+            'Some test error. Exception: {exception}',
             [
                 'exception' => $exception
             ]
@@ -123,7 +123,7 @@ class LoggerTest extends PHPUnit_Framework_TestCase
 
         Phake::verify($this->isolator)->fwrite(
             '<resource>',
-            '<date> ERRO Some test error.' . PHP_EOL
+            '<date> ERRO Some test error. Exception: This is the exception message.' . PHP_EOL
         );
 
         Phake::verify($this->isolator)->fwrite(


### PR DESCRIPTION
Added support for displaying just the exception message in the main substituted log message instead of the whole stack trace.